### PR TITLE
chore: create partial api interfaces for example

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{config_env()}.exs"

--- a/config/sandbox.exs
+++ b/config/sandbox.exs
@@ -1,0 +1,5 @@
+config :pomelo_ex,
+  client_id: "3LBFuOiEHrl4BailkRlsnIMmSctMLb7A",
+  client_secret: "s5u3oYK0-A9CV6TkszPQThUa_qxMfr2yyd3-eJwQ...",
+  audience: "https://auth-dev.pomelo.la",
+  grant_type: "client_credentials"

--- a/config/sandbox.exs
+++ b/config/sandbox.exs
@@ -1,5 +1,5 @@
 config :pomelo_ex,
-  client_id: "3LBFuOiEHrl4BailkRlsnIMmSctMLb7A",
-  client_secret: "s5u3oYK0-A9CV6TkszPQThUa_qxMfr2yyd3-eJwQ...",
-  audience: "https://auth-dev.pomelo.la",
-  grant_type: "client_credentials"
+  client_id: "",
+  client_secret: "",
+  audience: "",
+  grant_type: ""

--- a/lib/pomelo_ex.ex
+++ b/lib/pomelo_ex.ex
@@ -2,17 +2,4 @@ defmodule PomeloEx do
   @moduledoc """
   Documentation for `PomeloEx`.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> PomeloEx.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/lib/pomelo_ex/cards/associations.ex
+++ b/lib/pomelo_ex/cards/associations.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associate_credit.ex
+++ b/lib/pomelo_ex/cards/associations/associate_credit.ex
@@ -1,0 +1,16 @@
+defmodule PomeloEx.Cards.Associations.AssociateCredit do
+  @moduledoc """
+  This service allows you to associate a line of credit with a specific credit card.
+  """
+
+  alias PomeloEx.Cards.Associations.AssociateCredit.AssociateCardWithLineOfCredit
+  alias PomeloEx.Cards.Associations.AssociateCredit.GetAssociations
+  alias PomeloEx.Cards.Associations.AssociateCredit.GetAssociationsByCreditLine
+
+  defdelegate associate_card_with_line_of_credit(payload),
+    to: AssociateCardWithLineOfCredit,
+    as: :execute
+
+  defdelegate get_associations(payload), to: GetAssociations, as: :execute
+  defdelegate get_association_by_credit_line, to: GetAssociationsByCreditLine, as: :execute
+end

--- a/lib/pomelo_ex/cards/associations/associate_credit/associate_card_with_line_of_credit.ex
+++ b/lib/pomelo_ex/cards/associations/associate_credit/associate_card_with_line_of_credit.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.AssociateCredit.AssociateCardWithLineOfCredit do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associate_credit/get_associations.ex
+++ b/lib/pomelo_ex/cards/associations/associate_credit/get_associations.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.AssociateCredit.GetAssociations do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associate_credit/get_associations_by_credit_line.ex
+++ b/lib/pomelo_ex/cards/associations/associate_credit/get_associations_by_credit_line.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.AssociateCredit.GetAssociationsByCreditLine do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associations.ex
+++ b/lib/pomelo_ex/cards/associations/associations.ex
@@ -1,0 +1,9 @@
+defmodule PomeloEx.Cards.Associations.Associations do
+  alias PomeloEx.Cards.Associations.Associations.LinkCard
+  alias PomeloEx.Cards.Associations.Associations.SeacrhAssociations
+  alias PomeloEx.Cards.Associations.Associations.UnlinkCard
+
+  defdelegate link_card(payload), to: LinkCard, as: :execute
+  defdelegate search_associations(payload), to: SeacrhAssociations, as: :execute
+  defdelegate unlink_card(payload), to: UnlinkCard, as: :execute
+end

--- a/lib/pomelo_ex/cards/associations/associations/link_card.ex
+++ b/lib/pomelo_ex/cards/associations/associations/link_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.Associations.LinkCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associations/seacrh_associations.ex
+++ b/lib/pomelo_ex/cards/associations/associations/seacrh_associations.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.Associations.SeacrhAssociations do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/associations/associations/unlink_card.ex
+++ b/lib/pomelo_ex/cards/associations/associations/unlink_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Associations.Associations.UnlinkCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits.ex
+++ b/lib/pomelo_ex/cards/credits.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/allocations.ex
+++ b/lib/pomelo_ex/cards/credits/allocations.ex
@@ -1,0 +1,15 @@
+defmodule PomeloEx.Cards.Credits.Allocations do
+  @moduledoc """
+  This service enables you to report user payments and the associated benefits or charges over a credit line. Find more information about allocations in our [documentation](https://docs.pomelo.la/docs/cards/lending/payments).
+  """
+
+  alias PomeloEx.Cards.Credits.Allocations.CancelAllocation
+  alias PomeloEx.Cards.Credits.Allocations.GenerateAllocation
+  alias PomeloEx.Cards.Credits.Allocations.ObtainAllocation
+  alias PomeloEx.Cards.Credits.Allocations.ObtainAllocations
+
+  defdelegate cancel_allocation(payload), to: CancelAllocation, as: :execute
+  defdelegate generate_allocation(payload), to: GenerateAllocation, as: :execute
+  defdelegate obtain_allocation(payload), to: ObtainAllocation, as: :execute
+  defdelegate obtain_allocations(payload), to: ObtainAllocations, as: :execute
+end

--- a/lib/pomelo_ex/cards/credits/allocations/cancel_allocation.ex
+++ b/lib/pomelo_ex/cards/credits/allocations/cancel_allocation.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Allocations.CancelAllocation do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/allocations/generate_allocation.ex
+++ b/lib/pomelo_ex/cards/credits/allocations/generate_allocation.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Allocations.GenerateAllocation do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/allocations/obtain_allocation.ex
+++ b/lib/pomelo_ex/cards/credits/allocations/obtain_allocation.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Allocations.ObtainAllocation do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/allocations/obtain_allocations.ex
+++ b/lib/pomelo_ex/cards/credits/allocations/obtain_allocations.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Allocations.ObtainAllocations do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines.ex
@@ -1,0 +1,35 @@
+defmodule PomeloEx.Cards.Credits.CreditLines do
+  @moduledoc """
+  The Credit Lines service allows you to create and manage both credit products and credit lines
+
+  Want to know more about credit lines? Check out our [documentation](https://docs.pomelo.la/docs/cards/lending/credit-line).
+  """
+
+  alias PomeloEx.Cards.Credits.CreditLines.CancelCreditLine
+  alias PomeloEx.Cards.Credits.CreditLines.CreateCreditLine
+  alias PomeloEx.Cards.Credits.CreditLines.CreatePriceUpdate
+  alias PomeloEx.Cards.Credits.CreditLines.CreateProduct
+  alias PomeloEx.Cards.Credits.CreditLines.DeactivatingProduct
+  alias PomeloEx.Cards.Credits.CreditLines.GetCreditLine
+  alias PomeloEx.Cards.Credits.CreditLines.GetCreditLines
+  alias PomeloEx.Cards.Credits.CreditLines.GetPriceUpdateHistory
+  alias PomeloEx.Cards.Credits.CreditLines.GetProduct
+  alias PomeloEx.Cards.Credits.CreditLines.GetProducts
+  alias PomeloEx.Cards.Credits.CreditLines.ModifyPendingPriceUpdate
+  alias PomeloEx.Cards.Credits.CreditLines.UpdateCreditLine
+  alias PomeloEx.Cards.Credits.CreditLines.UpdateProduct
+
+  defdelegate cancel_credit_line(payload), to: CancelCreditLine, as: :execute
+  defdelegate create_credit_line(payload), to: CreateCreditLine, as: :execute
+  defdelegate create_price_update(payload), to: CreatePriceUpdate
+  defdelegate create_product(payload), to: CreateProduct, as: :execute
+  defdelegate deactivating_product(payload), to: DeactivatingProduct, as: :execute
+  defdelegate get_credit_line(payload), to: GetCreditLine, as: :execute
+  defdelegate get_credit_lines(payload), to: GetCreditLines, as: :execute
+  defdelegate get_price_update_history(payload), to: GetPriceUpdateHistory, as: :execute
+  defdelegate get_product(payload), to: GetProduct, as: :execute
+  defdelegate get_products(payload), to: GetProducts, as: :execute
+  defdelegate modify_pending_price_update(payload), to: ModifyPendingPriceUpdate, as: :execute
+  defdelegate update_credit_line(payload), to: UpdateCreditLine, as: :execute
+  defdelegate update_product(payload), to: UpdateProduct, as: :execute
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/cancel_credit_line.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/cancel_credit_line.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.CancelCreditLine do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/create_credit_line.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/create_credit_line.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.CreateCreditLine do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/create_price_update.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/create_price_update.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.CreatePriceUpdate do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/create_product.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/create_product.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.CreateProduct do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/deactivating_product.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/deactivating_product.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.DeactivatingProduct do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/get_credit_line.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/get_credit_line.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.GetCreditLine do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/get_credit_lines.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/get_credit_lines.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.GetCreditLines do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/get_price_update_history.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/get_price_update_history.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.GetPriceUpdateHistory do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/get_product.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/get_product.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.GetProduct do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/get_products.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/get_products.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.GetProducts do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/modify_pending_price_update.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/modify_pending_price_update.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.ModifyPendingPriceUpdate do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/update_credit_line.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/update_credit_line.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.UpdateCreditLine do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/credit_lines/update_product.ex
+++ b/lib/pomelo_ex/cards/credits/credit_lines/update_product.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.CreditLines.UpdateProduct do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/operations.ex
+++ b/lib/pomelo_ex/cards/credits/operations.ex
@@ -1,0 +1,9 @@
+defmodule PomeloEx.Cards.Credits.Operations do
+  @moduledoc """
+  This service allows you to query the performed operations.
+  """
+
+  alias PomeloEx.Cards.Credits.Operations.GetOperations
+
+  defdelegate get_operations(payload), to: GetOperations, as: :execute
+end

--- a/lib/pomelo_ex/cards/credits/operations/get_operations.ex
+++ b/lib/pomelo_ex/cards/credits/operations/get_operations.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Operations.GetOperations do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/statements.ex
+++ b/lib/pomelo_ex/cards/credits/statements.ex
@@ -1,0 +1,15 @@
+defmodule PomeloEx.Cards.Credits.Statements do
+  @moduledoc """
+  This service allows you to inquire about the account statements for the different Credit Lines. Find more information about Account Statements in our [documentation](https://docs.pomelo.la/docs/cards/lending/statements).
+  """
+
+  alias PomeloEx.Cards.Credits.Statements.GetFollowingStatements
+  alias PomeloEx.Cards.Credits.Statements.GetLastStatements
+  alias PomeloEx.Cards.Credits.Statements.GetStatement
+  alias PomeloEx.Cards.Credits.Statements.SearchAccountStatements
+
+  defdelegate get_following_statements(payload), to: GetFollowingStatements, as: :execute
+  defdelegate get_last_statements(payload), to: GetLastStatements, as: :execute
+  defdelegate get_statement(payload), to: GetStatement, as: :execute
+  defdelegate search_account_statements(payload), to: SearchAccountStatements, as: :execute
+end

--- a/lib/pomelo_ex/cards/credits/statements/get_following_statements.ex
+++ b/lib/pomelo_ex/cards/credits/statements/get_following_statements.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Statements.GetFollowingStatements do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/statements/get_last_statements.ex
+++ b/lib/pomelo_ex/cards/credits/statements/get_last_statements.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Statements.GetLastStatements do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/statements/get_statement.ex
+++ b/lib/pomelo_ex/cards/credits/statements/get_statement.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Statements.GetStatement do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/statements/search_account_statements.ex
+++ b/lib/pomelo_ex/cards/credits/statements/search_account_statements.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Statements.SearchAccountStatements do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/webhooks.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks.ex
@@ -1,0 +1,53 @@
+defmodule PomeloEx.Cards.Credits.Webhooks do
+  @moduledoc """
+  This service will be in charge of notifying you of events related to credit cards.
+
+  Digital signature request verification process#
+  We send a set of HTTP headers to authenticate it along with the notification.
+
+  The HTTP headers we send are:
+
+  x-api-key : this header allows you to identify which api-secret you have to use in the event that multiple api-key and api-secret pairs have been configured.
+
+  x-signature : This header contains the digital signature (body + timestamp + endpoint) that must be verified to ensure request integrity. If the signature does not match, reject the order.
+
+  x-timestamp : this header contains the moment the order was signed in unix-epoch format so that you can verify that the signature has not expired.
+
+  x-endpoint : the endpoint to which the request is made and used to generate the signature. Use this header to regenerate the signature to be validated, compare it with the endpoint of your service and verify that they match.
+
+  The digital signature is an HMAC-SHA256 code constructed using the 'api-secret' and a series of bytes, composed of a timestamp concatenation, endpoint and request body coded in UTF-8.
+
+  The following is a pseudo-code to verify that the digital signature of a request is legitimate:
+
+  requestSignature = request.headers['x-signature']
+  signatureData = encode(request.headers['x-timestamp'] + request.headers['x-endpoint'] + request.body , 'UTF-8')
+  recreatedSignature = hmac(apiSecret, signatureData, 'SHA256')
+  validSignature = requestSignature == recreatedSignature
+  """
+
+  alias PomeloEx.Cards.Credits.Webhooks.CreatedSummariesNotifications
+  alias PomeloEx.Cards.Credits.Webhooks.CreditLinePauseUnpauseNotifications
+  alias PomeloEx.Cards.Credits.Webhooks.EntryExitFromArrearsUserNotifications
+  alias PomeloEx.Cards.Credits.Webhooks.ProcessedTransactionsNotifications
+  alias PomeloEx.Cards.Credits.Webhooks.ReversedTransactionsNotifications
+
+  defdelegate created_summaries_notifications(payload),
+    to: CreatedSummariesNotifications,
+    as: :execute
+
+  defdelegate credit_line_pause_unpause_notifications(payload),
+    to: CreditLinePauseUnpauseNotifications,
+    as: :execute
+
+  defdelegate entry_exit_from_arrears_user_notifications(payload),
+    to: EntryExitFromArrearsUserNotifications,
+    as: :execute
+
+  defdelegate processed_transactions_notifications(payload),
+    to: ProcessedTransactionsNotifications,
+    as: :execute
+
+  defdelegate reversed_transactions_notifications(payload),
+    to: ReversedTransactionsNotifications,
+    as: :execute
+end

--- a/lib/pomelo_ex/cards/credits/webhooks/created_summaries_notifications.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks/created_summaries_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Webhooks.CreatedSummariesNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/webhooks/credit_line_pause_unpause_notifications.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks/credit_line_pause_unpause_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Webhooks.CreditLinePauseUnpauseNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/webhooks/entry_exit_from_arrears_user_notifications.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks/entry_exit_from_arrears_user_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Webhooks.EntryExitFromArrearsUserNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/webhooks/processed_transactions_notifications.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks/processed_transactions_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Webhooks.ProcessedTransactionsNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/credits/webhooks/reversed_transactions_notifications.ex
+++ b/lib/pomelo_ex/cards/credits/webhooks/reversed_transactions_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Credits.Webhooks.ReversedTransactionsNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing.ex
+++ b/lib/pomelo_ex/cards/issuing.ex
@@ -1,0 +1,2 @@
+defmodule PomeloEx.Cards.Issuing do
+end

--- a/lib/pomelo_ex/cards/issuing/cards.ex
+++ b/lib/pomelo_ex/cards/issuing/cards.ex
@@ -1,0 +1,29 @@
+defmodule PomeloEx.Cards.Issuing.Cards do
+  @moduledoc """
+  Cards
+  The Cards API contains all the endpoints needed to create nominate and innominate cards, activate them, run queries, retrieve information on a particular card, and more.
+  """
+  alias PomeloEx.Cards.Issuing.Cards.UpdateCard
+  alias PomeloEx.Cards.Issuing.Cards.UpdateCardShipping
+  alias PomeloEx.Cards.Issuing.Cards.UpdateCardBatchShipping
+  alias PomeloEx.Cards.Issuing.Cards.SearchCards
+  alias PomeloEx.Cards.Issuing.Cards.GetCard
+  alias PomeloEx.Cards.Issuing.Cards.GetAffinityGroup
+  alias PomeloEx.Cards.Issuing.Cards.CreateMultipleBatchInnominateCards
+  alias PomeloEx.Cards.Issuing.Cards.CreateBatchInnominateCards
+  alias PomeloEx.Cards.Issuing.Cards.CardEvents
+  alias PomeloEx.Cards.Issuing.Cards.ActivateCard
+
+
+  defdelegate activate_card(payload), to: ActivateCard, as: :execute
+  defdelegate card_events(payload),to: CardEvents, as: :execute
+  defdelegate create_batch_innominate_cards(payload), to: CreateBatchInnominateCards, as: :execute
+  defdelegate create_multiple_batch_innominate_cards(payload), to: CreateMultipleBatchInnominateCards, as: :execute
+  defdelegate get_affinity_group(payload), to: GetAffinityGroup, as: :execute
+  defdelegate get_card(payload), to: GetCard, as: :execute
+  defdelegate search_cards(payload), to: SearchCards, as: :execute
+  defdelegate update_card_batch_shipping(payload), to: UpdateCardBatchShipping, as: :execute
+  defdelegate update_card_shipping(payload), to: UpdateCardShipping, as: :execute
+  defdelegate update_card(payload), to: UpdateCard, as: :execute
+
+end

--- a/lib/pomelo_ex/cards/issuing/cards.ex
+++ b/lib/pomelo_ex/cards/issuing/cards.ex
@@ -14,16 +14,18 @@ defmodule PomeloEx.Cards.Issuing.Cards do
   alias PomeloEx.Cards.Issuing.Cards.CardEvents
   alias PomeloEx.Cards.Issuing.Cards.ActivateCard
 
-
   defdelegate activate_card(payload), to: ActivateCard, as: :execute
-  defdelegate card_events(payload),to: CardEvents, as: :execute
+  defdelegate card_events(payload), to: CardEvents, as: :execute
   defdelegate create_batch_innominate_cards(payload), to: CreateBatchInnominateCards, as: :execute
-  defdelegate create_multiple_batch_innominate_cards(payload), to: CreateMultipleBatchInnominateCards, as: :execute
+
+  defdelegate create_multiple_batch_innominate_cards(payload),
+    to: CreateMultipleBatchInnominateCards,
+    as: :execute
+
   defdelegate get_affinity_group(payload), to: GetAffinityGroup, as: :execute
   defdelegate get_card(payload), to: GetCard, as: :execute
   defdelegate search_cards(payload), to: SearchCards, as: :execute
   defdelegate update_card_batch_shipping(payload), to: UpdateCardBatchShipping, as: :execute
   defdelegate update_card_shipping(payload), to: UpdateCardShipping, as: :execute
   defdelegate update_card(payload), to: UpdateCard, as: :execute
-
 end

--- a/lib/pomelo_ex/cards/issuing/cards/activate_card.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/activate_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.ActivateCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/card_events.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/card_events.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.CardEvents do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/create_batch_innominate_cards.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/create_batch_innominate_cards.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.CreateBatchInnominateCards do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/create_card.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/create_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.CreateCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/create_multiple_batch_innominate_cards.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/create_multiple_batch_innominate_cards.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.CreateMultipleBatchInnominateCards do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/get_affinity_group.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/get_affinity_group.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.GetAffinityGroup do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/get_card.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/get_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.GetCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/search_cards.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/search_cards.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.SearchCards do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/update_card.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/update_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.UpdateCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/update_card_batch_shipping.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/update_card_batch_shipping.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.UpdateCardBatchShipping do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/cards/update_card_shipping.ex
+++ b/lib/pomelo_ex/cards/issuing/cards/update_card_shipping.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Cards.UpdateCardShipping do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments.ex
@@ -1,0 +1,26 @@
+defmodule PomeloEx.Cards.Issuing.Shipments do
+  @moduledoc """
+  The Shipping API comprises all the endpoints for creating shipments and retrieving data for your created shipments. You will also find endpoints to receive notifications about updates on the status of your shipments via a webhook.
+
+  External shipments#
+  When defining your integration, you will have the option to NOT use our card distribution service.
+
+  In that case, the affinity groups will reflect the settings you have chosen. Also, when creating a card or a batch of cards, we will return an identifier in the shipment_id field, which we recommend you store in your integration, since you will need it for pick-up. The cards will be available for pick-up at the embossing facility specified in integration.
+  """
+
+  alias PomeloEx.Cards.Issuing.Shipments.ChangeShipmentData
+  alias PomeloEx.Cards.Issuing.Shipments.CreateShipment
+  alias PomeloEx.Cards.Issuing.Shipments.GetShipment
+  alias PomeloEx.Cards.Issuing.Shipments.GetShipmentHistory
+  alias PomeloEx.Cards.Issuing.Shipments.RequestReceiverData
+  alias PomeloEx.Cards.Issuing.Shipments.SearchShipment
+  alias PomeloEx.Cards.Issuing.Shipments.ShipmentNotifications
+
+  defdelegate change_shipment_data(payload), to: ChangeShipmentData, as: :execute
+  defdelegate create_shipment(payload), to: CreateShipment, as: :execute
+  defdelegate get_shipment(payload), to: GetShipment, as: :execute
+  defdelegate get_shipment_history(payload), to: GetShipmentHistory, as: :execute
+  defdelegate request_receiver_data(payload), to: RequestReceiverData, as: :execute
+  defdelegate search_shipment(payload), to: SearchShipment, as: :execute
+  defdelegate shipment_notifications(payload), to: ShipmentNotifications, as: :execute
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/change_shipment_data.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/change_shipment_data.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.ChangeShipmentData do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/create_shipment.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/create_shipment.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.CreateShipment do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/get_shipment.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/get_shipment.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.GetShipment do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/get_shipment_history.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/get_shipment_history.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.GetShipmentHistory do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/request_receiver_data.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/request_receiver_data.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.RequestReceiverData do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/search_shipment.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/search_shipment.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.SearchShipment do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/issuing/shipments/shipment_notifications.ex
+++ b/lib/pomelo_ex/cards/issuing/shipments/shipment_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Issuing.Shipments.ShipmentNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing.ex
+++ b/lib/pomelo_ex/cards/processing.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing/summaries.ex
+++ b/lib/pomelo_ex/cards/processing/summaries.ex
@@ -1,0 +1,11 @@
+defmodule PomeloEx.Cards.Processing.Summaries do
+  @moduledoc """
+  The Statements API is only available for credit cards issued in Argentina and for those who have not implemented the Credits solution, which means they have not contracted the lending engine
+  """
+
+  alias PomeloEx.Cards.Processing.Summaries.CalculateTaxes
+  alias PomeloEx.Cards.Processing.Summaries.RetrieveTaxes
+
+  defdelegate calculate_taxes(payload), to: CalculateTaxes, as: :execute
+  defdelegate retrieve_taxes(payload), to: RetrieveTaxes, as: :execute
+end

--- a/lib/pomelo_ex/cards/processing/summaries/calculate_taxes.ex
+++ b/lib/pomelo_ex/cards/processing/summaries/calculate_taxes.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing.Summaries.CalculateTaxes do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing/summaries/retrieve_taxes.ex
+++ b/lib/pomelo_ex/cards/processing/summaries/retrieve_taxes.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing.Summaries.RetrieveTaxes do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing/transactions.ex
+++ b/lib/pomelo_ex/cards/processing/transactions.ex
@@ -1,0 +1,15 @@
+defmodule PomeloEx.Cards.Processing.Transactions do
+  @moduledoc """
+  You must implement and expose the “Authorization” and “ Adjustments” endpoints on your backend so that we can communicate.
+
+  See [documentation](https://developers.pomelo.la/en/api-reference/cards/processing/transactions) to know the processor flow
+  """
+
+  alias PomeloEx.Cards.Processing.Transactions.Adjustments
+  alias PomeloEx.Cards.Processing.Transactions.AuthorizeTransaction
+  alias PomeloEx.Cards.Processing.Transactions.Notifications
+
+  defdelegate adjustments(payload), to: Adjustments, as: :execute
+  defdelegate authorize_transaction(payload), to: AuthorizeTransaction, as: :execute
+  defdelegate notifications(payload), to: Notifications, as: :execute
+end

--- a/lib/pomelo_ex/cards/processing/transactions/adjustments.ex
+++ b/lib/pomelo_ex/cards/processing/transactions/adjustments.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing.Transactions.Adjustments do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing/transactions/authorize_transaction.ex
+++ b/lib/pomelo_ex/cards/processing/transactions/authorize_transaction.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing.Transactions.AuthorizeTransaction do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/processing/transactions/notifications.ex
+++ b/lib/pomelo_ex/cards/processing/transactions/notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Processing.Transactions.Notifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/sensitive_information.ex
+++ b/lib/pomelo_ex/cards/sensitive_information.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.SensitiveInformation do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/sensitive_information/authorization.ex
+++ b/lib/pomelo_ex/cards/sensitive_information/authorization.ex
@@ -1,0 +1,9 @@
+defmodule PomeloEx.Cards.SensitiveInformation.Authorization do
+  @moduledoc """
+  With this API you can authenticate a user to display sensitive card information.
+  """
+
+  alias PomeloEx.Cards.SensitiveInformation.Authorization.CreateUserToken
+
+  defdelegate create_user_token(payload), to: CreateUserToken, as: :execute
+end

--- a/lib/pomelo_ex/cards/sensitive_information/authorization/create_user_token.ex
+++ b/lib/pomelo_ex/cards/sensitive_information/authorization/create_user_token.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.SensitiveInformation.Authorization.CreateUserToken do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/sensitive_information/handling.ex
+++ b/lib/pomelo_ex/cards/sensitive_information/handling.ex
@@ -1,0 +1,19 @@
+defmodule PomeloEx.Cards.SensitiveInformation.Handling do
+  @moduledoc """
+  Integration Flow#
+  To display sensitive information or activated your users' cards, follow these steps:
+
+  1. Ask us for an end user token with the token you obtained in 'Authorization'. [See documentation](https://developers.pomelo.la/en/api-reference)
+  2. Use this new token as a query parameter embedding the Pomelo website in your UI.
+  3. Set the styles you want and the required parameters.
+  """
+
+  alias PomeloEx.Cards.SensitiveInformation.Handling.ActivateCard
+  alias PomeloEx.Cards.SensitiveInformation.Handling.DisplaySensitiveInformation
+
+  defdelegate activate_card(payload), to: ActivateCard, as: :execute
+
+  defdelegate display_sensitive_information(payload),
+    to: DisplaySensitiveInformation,
+    as: :execute
+end

--- a/lib/pomelo_ex/cards/sensitive_information/handling/activate_card.ex
+++ b/lib/pomelo_ex/cards/sensitive_information/handling/activate_card.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.SensitiveInformation.Handling.ActivateCard do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/sensitive_information/handling/display_sensitive_information.ex
+++ b/lib/pomelo_ex/cards/sensitive_information/handling/display_sensitive_information.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.SensitiveInformation.Handling.DisplaySensitiveInformation do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/tokenization.ex
+++ b/lib/pomelo_ex/cards/tokenization.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Tokenization do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/tokenization/mastercard.ex
+++ b/lib/pomelo_ex/cards/tokenization/mastercard.ex
@@ -1,0 +1,12 @@
+defmodule PomeloEx.Cards.Tokenization.Mastercard do
+  @moduledoc """
+  The following endpoints are used during the [push provisioning flow](https://docs.pomelo.la/en/docs/cards/features/tokenization/provisioning) to generate the cryptographic data that your application needs to send to the virtual wallet. Before using them, confirm with our integrations team that you have everything prepared.
+
+  Want to know more about Tokenization integration? We provide all the details in [our documentation](https://docs.pomelo.la/en/docs/cards/features/tokenization/home).
+  """
+  alias PomeloEx.Cards.Tokenization.Mastercard.ProvisioningApplePay
+  alias PomeloEx.Cards.Tokenization.Mastercard.ProvisioningGooglePay
+
+  defdelegate provisioning_apple_pay(payload), to: ProvisioningApplePay, as: :execute
+  defdelegate provisioning_google_pay(payload), to: ProvisioningGooglePay, as: :execute
+end

--- a/lib/pomelo_ex/cards/tokenization/mastercard/provisioning_apple_pay.ex
+++ b/lib/pomelo_ex/cards/tokenization/mastercard/provisioning_apple_pay.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Tokenization.Mastercard.ProvisioningApplePay do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/tokenization/mastercard/provisioning_google_pay.ex
+++ b/lib/pomelo_ex/cards/tokenization/mastercard/provisioning_google_pay.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Tokenization.Mastercard.ProvisioningGooglePay do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/tokenization/visa.ex
+++ b/lib/pomelo_ex/cards/tokenization/visa.ex
@@ -1,0 +1,13 @@
+defmodule PomeloEx.Cards.Tokenization.Visa do
+  @moduledoc """
+  The following endpoints are used during the [push provisioning flow](https://docs.pomelo.la/en/docs/cards/features/tokenization/provisioning) to generate the cryptographic data that your application needs to send to the virtual wallet. Before using them, confirm with our integrations team that you have everything prepared.
+
+  Want to know more about Tokenization integration? We provide all the details in [our documentation](https://docs.pomelo.la/en/docs/cards/features/tokenization/home).
+  """
+
+  alias PomeloEx.Cards.Tokenization.Visa.ProvisioningApplePay
+  alias PomeloEx.Cards.Tokenization.Visa.ProvisioningGooglePay
+
+  defdelegate provisioning_apple_pay(payload), to: ProvisioningApplePay, as: :execute
+  defdelegate provisioning_google_pay(payload), to: ProvisioningGooglePay, as: :execute
+end

--- a/lib/pomelo_ex/cards/tokenization/visa/provisioning_apple_pay.ex
+++ b/lib/pomelo_ex/cards/tokenization/visa/provisioning_apple_pay.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Tokenization.Visa.ProvisioningApplePay do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/cards/tokenization/visa/provisioning_google_pay.ex
+++ b/lib/pomelo_ex/cards/tokenization/visa/provisioning_google_pay.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Cards.Tokenization.Visa.ProvisioningGooglePay do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/accounts.ex
+++ b/lib/pomelo_ex/digital_accounts/accounts.ex
@@ -1,0 +1,9 @@
+defmodule PomeloEx.DigitalAccounts.Accounts do
+  alias PomeloEx.DigitalAccounts.Accounts.CreateAccount
+  alias PomeloEx.DigitalAccounts.Accounts.DeleteAccount
+  alias PomeloEx.DigitalAccounts.Accounts.UpdateAccountStatus
+
+  defdelegate create_account(payload), to: CreateAccount, as: :execute
+  defdelegate delete_account(payload), to: DeleteAccount, as: :execute
+  defdelegate update_account_status(payload), to: UpdateAccountStatus, as: :execute
+end

--- a/lib/pomelo_ex/digital_accounts/accounts/create_account.ex
+++ b/lib/pomelo_ex/digital_accounts/accounts/create_account.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Accounts.CreateAccount do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/accounts/delete_account.ex
+++ b/lib/pomelo_ex/digital_accounts/accounts/delete_account.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Accounts.DeleteAccount do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/accounts/update_account_status.ex
+++ b/lib/pomelo_ex/digital_accounts/accounts/update_account_status.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Accounts.UpdateAccountStatus do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P.ex
+++ b/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P.ex
@@ -1,0 +1,8 @@
+defmodule PomeloEx.DigitalAccounts.DigitalMovementsAndP2P do
+  alias PomeloEx.DigitalAccounts.DigitalMovementsAndP2P.AuthorizeDigitalMovements
+  alias PomeloEx.DigitalAccounts.DigitalMovementsAndP2P.AuthorizeP2PTransaction
+
+  defdelegate authorize_digital_movements(payload), to: AuthorizeDigitalMovements, as: :execute
+
+  defdelegate authorize_P2P_transaction(payload), to: AuthorizeP2PTransaction, as: :execute
+end

--- a/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P/authorize_P2P_transaction.ex
+++ b/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P/authorize_P2P_transaction.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.DigitalMovementsAndP2P.AuthorizeP2PTransaction do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P/authorize_digital_movements.ex
+++ b/lib/pomelo_ex/digital_accounts/digital_movements_and_P2P/authorize_digital_movements.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.DigitalMovementsAndP2P.AuthorizeDigitalMovements do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/queries.ex
+++ b/lib/pomelo_ex/digital_accounts/queries.ex
@@ -1,0 +1,14 @@
+defmodule PomeloEx.DigitalAccounts.Queries do
+  alias PomeloEx.DigitalAccounts.Queries.GetAccount
+  alias PomeloEx.DigitalAccounts.Queries.GetActivity
+  alias PomeloEx.DigitalAccounts.Queries.ListAccounts
+  alias PomeloEx.DigitalAccounts.Queries.ListActivities
+
+  defdelegate get_account(payload), to: GetAccount, as: :execute
+
+  defdelegate get_activity(payload), to: GetActivity, as: :execute
+
+  defdelegate list_accounts(payload), to: ListAccounts, as: :execute
+
+  defdelegate list_activities(payload), to: ListActivities, as: :execute
+end

--- a/lib/pomelo_ex/digital_accounts/queries/get_account.ex
+++ b/lib/pomelo_ex/digital_accounts/queries/get_account.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Queries.GetAccount do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/queries/get_activity.ex
+++ b/lib/pomelo_ex/digital_accounts/queries/get_activity.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Queries.GetActivity do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/queries/list_accounts.ex
+++ b/lib/pomelo_ex/digital_accounts/queries/list_accounts.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Queries.ListAccounts do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/queries/list_activities.ex
+++ b/lib/pomelo_ex/digital_accounts/queries/list_activities.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Queries.ListActivities do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/digital_accounts/webhooks.ex
+++ b/lib/pomelo_ex/digital_accounts/webhooks.ex
@@ -1,0 +1,17 @@
+defmodule PomeloEx.DigitalAccounts.Webhooks do
+  @moduledoc """
+  This service notifies you of all account activities.
+
+  You will receive notifications for either the creation or modification of an activity. To determine the type of case, read the type field, which will show one of these values:
+
+   - ACTIVITY_CREATED: when a new activity is created.
+   - ACTIVITY_UPDATED: when an activity is modified. Activities may change their status from PENDING to APPROVED or from PENDING to REJECTED.
+  You can find more information in the [Webhooks Configuration](https://docs.pomelo.la/en/docs/developers/webhooks).
+
+  You can also find more information about the [Verification Process](https://docs.pomelo.la/docs/developers/key-exchange) of the digital signature.
+  """
+
+  alias PomeloEx.DigitalAccounts.Webhooks.ActivityNotification
+
+  defdelegate activity_notification(payload), to: ActivityNotification, as: :execute
+end

--- a/lib/pomelo_ex/digital_accounts/webhooks/activity_notification.ex
+++ b/lib/pomelo_ex/digital_accounts/webhooks/activity_notification.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.DigitalAccounts.Webhooks.ActivityNotification do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/chargebacks.ex
+++ b/lib/pomelo_ex/fraud_prevention/chargebacks.ex
@@ -1,0 +1,30 @@
+defmodule PomeloEx.FraudPrevention.Chargebacks do
+  @doc """
+  The Pomelo Chargeback Service is a comprehensive solution designed to facilitate and optimize the chargeback management of payment transactions made through the Pomelo platform.
+
+  What is a chargeback?#
+  A chargeback is a refund request for a payment made through the Pomelo platform.
+
+  Chargebacks status#
+  All chargebacks have a status field describing which state of the management process they are in. The possible chargeback statuses are the following:
+
+    - PENDING: The chargeback is in pending status.
+    - UNDER_EVALUATION: A first analysis of the chargeback is underway, and more information is needed to continue with the dispute.
+    - DISPUTE_OPEN: The transaction dispute was opened with the brand (Mastercard or Visa) and we are waiting for their response.
+    - DISPUTE_REJECTED: The dispute was rejected by the brand since the transaction did not meet the requirements to be disputed.
+    - DISPUTE_WON: The dispute was won in favor of the issuer.
+    - DISPUTE_LOST: The dispute was lost; in this case, the liability remains on the issuer's or cardholder's side.
+    - DISPUTE_NOT_PROCESSED: No pudimos procesar el contracargo dadas las características del pago.
+    - TRANSACTION_NOT_PRESENTED: La transacción aún no ha sido presentada por el adquirente, por lo que no es posible solicitar un contracargo.
+  """
+
+  alias PomeloEx.FraudPrevention.Chargebacks.AttachFileToChargeback
+  alias PomeloEx.FraudPrevention.Chargebacks.CreateChargeback
+  alias PomeloEx.FraudPrevention.Chargebacks.FindChargebacks
+  alias PomeloEx.FraudPrevention.Chargebacks.ObtainChargeback
+
+  defdelegate attach_file_to_chargeback(payload), to: AttachFileToChargeback, as: :execute
+  defdelegate create_chargeback(payload), to: CreateChargeback, as: :execute
+  defdelegate find_chargebacks(payload), to: FindChargebacks, as: :execute
+  defdelegate obtain_chargeback(payload), to: ObtainChargeback, as: :execute
+end

--- a/lib/pomelo_ex/fraud_prevention/chargebacks/attach_file_to_chargeback.ex
+++ b/lib/pomelo_ex/fraud_prevention/chargebacks/attach_file_to_chargeback.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Chargebacks.AttachFileToChargeback do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/chargebacks/create_chargeback.ex
+++ b/lib/pomelo_ex/fraud_prevention/chargebacks/create_chargeback.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Chargebacks.CreateChargeback do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/chargebacks/find_chargebacks.ex
+++ b/lib/pomelo_ex/fraud_prevention/chargebacks/find_chargebacks.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Chargebacks.FindChargebacks do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/chargebacks/obtain_chargeback.ex
+++ b/lib/pomelo_ex/fraud_prevention/chargebacks/obtain_chargeback.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Chargebacks.ObtainChargeback do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/restriction.ex
+++ b/lib/pomelo_ex/fraud_prevention/restriction.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Restriction do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/restriction/merchant.ex
+++ b/lib/pomelo_ex/fraud_prevention/restriction/merchant.ex
@@ -1,0 +1,13 @@
+defmodule PomeloEx.FraudPrevention.Restriction.Merchant do
+  @moduledoc """
+  It is a tool that will allow you to block merchants for a certain period of time by entering their exact name.
+  """
+
+  alias PomeloEx.FraudPrevention.Restriction.Merchant.BlockMerchant
+  alias PomeloEx.FraudPrevention.Restriction.Merchant.GetBlockedMerchants
+  alias PomeloEx.FraudPrevention.Restriction.Merchant.RemoveBlockFromMerchant
+
+  defdelegate block_merchant(payload), to: BlockMerchant, as: :execute
+  defdelegate get_blocked_merchant(payload), to: GetBlockedMerchants, as: :execute
+  defdelegate remove_block_from_merchant(payload), to: RemoveBlockFromMerchant, as: :execute
+end

--- a/lib/pomelo_ex/fraud_prevention/restriction/merchant/block_merchant.ex
+++ b/lib/pomelo_ex/fraud_prevention/restriction/merchant/block_merchant.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Restriction.Merchant.BlockMerchant do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/restriction/merchant/get_blocked_merchants.ex
+++ b/lib/pomelo_ex/fraud_prevention/restriction/merchant/get_blocked_merchants.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Restriction.Merchant.GetBlockedMerchants do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/restriction/merchant/remove_block_from_merchant.ex
+++ b/lib/pomelo_ex/fraud_prevention/restriction/merchant/remove_block_from_merchant.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.Restriction.Merchant.RemoveBlockFromMerchant do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/travel_notice.ex
+++ b/lib/pomelo_ex/fraud_prevention/travel_notice.ex
@@ -1,0 +1,13 @@
+defmodule PomeloEx.FraudPrevention.TravelNotice do
+  @moduledoc """
+  Pomelo's Travel Notification is a service that enables you to temporarily increase the transaction limits for your users when they make purchases in a different country. If they have multiple cards, the Travel Notification will apply to all of them.
+  """
+
+  alias PomeloEx.FraudPrevention.TravelNotice.CreateTravelNotice
+  alias PomeloEx.FraudPrevention.TravelNotice.ObtainTravelNotification
+  alias PomeloEx.FraudPrevention.TravelNotice.UpdateTravelNotification
+
+  defdelegate create_travel_notice(payload), to: CreateTravelNotice, as: :execute
+  defdelegate obtain_travel_notification(payload), to: ObtainTravelNotification, as: :execute
+  defdelegate update_travel_notification(payload), to: UpdateTravelNotification, as: :execute
+end

--- a/lib/pomelo_ex/fraud_prevention/travel_notice/create_travel_notice.ex
+++ b/lib/pomelo_ex/fraud_prevention/travel_notice/create_travel_notice.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.TravelNotice.CreateTravelNotice do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/travel_notice/obtain_travel_notification.ex
+++ b/lib/pomelo_ex/fraud_prevention/travel_notice/obtain_travel_notification.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.TravelNotice.ObtainTravelNotification do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/fraud_prevention/travel_notice/update_travel_notification.ex
+++ b/lib/pomelo_ex/fraud_prevention/travel_notice/update_travel_notification.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.FraudPrevention.TravelNotice.UpdateTravelNotification do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/authorization.ex
+++ b/lib/pomelo_ex/general/authorization.ex
@@ -1,0 +1,32 @@
+defmodule PomeloEx.General.Authorization do
+  @moduledoc """
+  Authorization
+  We implemented the OAuth 2.0 standard so you can communicate with our APIs with a single Bearer token.
+
+  Using the token#
+  Once you receive the access token, you must include it as an authorization header every time you communicate with our APIs.
+
+  Example in Curl:
+
+  curl https://api.pomelo.la -H 'Authorization: Bearer eyJhbGciOiJSUzI1Ni'
+  Each API validates the access token and verifies that the scope matches the required permissions.
+
+  For the requests to be valid, communicate with our APIs only via HTTPS and include the authorization header indicating that it is a Bearer type.
+  """
+
+  @doc """
+  Request token
+  The endpoint /oauth/token is used to obtain an access token. When performing a successful authentication, be sure to save it as you will need it to communicate with our APIs.
+
+  Each token is a JWT that contains an expiration time. We will return the same token to you each time you request one, until it expires. When it expires, we will provide a new one.
+  """
+  alias PomeloEx.General.Authorization.RequestToken
+  defdelegate request_token(payload), to: RequestToken, as: :execute
+
+  @doc """
+  Revoke token
+  The '/oauth/token/revoke' endpoint is used to revoke an access token from our cache. By revoking the token you can request a new one with the '/oauth/token' endpoint
+  """
+  alias PomeloEx.General.Authorization.RevokeToken
+  defdelegate revoke_token(payload), to: RevokeToken, as: :execute
+end

--- a/lib/pomelo_ex/general/authorization/request_token.ex
+++ b/lib/pomelo_ex/general/authorization/request_token.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Authorization.RequestToken do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/authorization/revoke_token.ex
+++ b/lib/pomelo_ex/general/authorization/revoke_token.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Authorization.RevokeToken do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/company.ex
+++ b/lib/pomelo_ex/general/company.ex
@@ -1,2 +1,76 @@
 defmodule PomeloEx.General.Company do
+  @moduledoc """
+  Company
+  The Companies API contains all the endpoints needed to manage the company bases.
+  You can use it to create, update or even search for companies under certain parameters.
+  """
+
+  @doc """
+  Create company
+  The /companies/v1/ endpoint enables you to create a new company in our database.
+
+  General considerations#
+  Para el campo operation_country esperamos un código de 3 caracteres respetando el estándar ISO
+  Here is a list of examples:
+
+  ARG
+  BRA
+  CHL
+  COL
+  MEX
+  PER
+
+  Points to keep in mind for tax documents#
+  Brazil: A CNPJ is an acceptable tax document.
+
+  Argentina: The type of fiscal document accepted is the CUIT. Campos requeridos: legal_address, email, tradeName, legalName, phone, type, tax_condition
+  """
+
+  alias PomeloEx.General.Company.CreateCompany
+  defdelegate create_company(payload), to: CreateCompany, as: :execute
+
+  @doc """
+  Search for companies
+  The '/users/v1/' endpoint enables you to search for a group of users and receive a list sorted according to the parameters specified.
+
+  Considerations#
+  You may specify your filters as parameters following this pattern: filter[campo]=valor. For example: /companies/v1/?filter[status]=ACTIVE To filter an attribute for several possible values, separate the values with commas. For example: filter[status]=ACTIVE,BLOCKED
+
+  The results are paginated and you can specify the amount of data per page and also which page to view using: page[number]=value and page[size]=value
+
+  Sorting#
+  You can specify the order of the results with certain parameters that you must send as list of strings in the sort filter type. For example: ?filter[status]=ACTIVE&sort=status
+
+  The default sorting will be ascending. To specify a descending sorting, you must send the character '-' as a prefix of the attribute. For example: /companies/v1/?filter[status]=ACTIVE&sort=status,-tax_identification_type
+
+  The possible sorting attributes are:
+
+  id
+  legal_name
+  trade_name
+  tax_identification_type
+  tax_identification_value
+  status
+  """
+  alias PomeloEx.General.Company.SearchCompanies
+  defdelegate search_companies, to: SearchCompanies, as: :execute
+
+  @doc """
+  Get Company
+  The /companies/v1/{id} endpoint enables you to query a company's information through its id.
+  """
+  alias PomeloEx.General.Company.GetCompany
+  defdelegate get_company(payload), to: GetCompany, as: :execute
+
+  @doc """
+  Modify Company
+  The endpoint '/companies/v1/{id}' enables you to update a company's information through its id. Updating a company is only possible if it has not been validated.
+
+  Considerations#
+  To block a company, you must send the 'status' with the value 'BLOCKED' and the value 'CLIENT_INTERNAL_REASON' in the field 'status_reason'.
+
+  To reactivate a company that you have blocked, you will need to submit the 'status' with an 'ACTIVE' value.
+  """
+  alias PomeloEx.General.Company.ModifyCompany
+  defdelegate modify_company(payload), to: ModifyCompany, as: :execute
 end

--- a/lib/pomelo_ex/general/company.ex
+++ b/lib/pomelo_ex/general/company.ex
@@ -53,7 +53,7 @@ defmodule PomeloEx.General.Company do
   status
   """
   alias PomeloEx.General.Company.SearchCompanies
-  defdelegate search_companies, to: SearchCompanies, as: :execute
+  defdelegate search_companies(payload), to: SearchCompanies, as: :execute
 
   @doc """
   Get Company

--- a/lib/pomelo_ex/general/company.ex
+++ b/lib/pomelo_ex/general/company.ex
@@ -1,0 +1,2 @@
+defmodule PomeloEx.General.Company do
+end

--- a/lib/pomelo_ex/general/company/create_company.ex
+++ b/lib/pomelo_ex/general/company/create_company.ex
@@ -1,4 +1,4 @@
-defmodule PomeloEx.Cards.Issuing do
+defmodule PomeloEx.General.Company.CreateCompany do
   def execute(payload) do
     raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
   end

--- a/lib/pomelo_ex/general/company/get_company.ex
+++ b/lib/pomelo_ex/general/company/get_company.ex
@@ -1,4 +1,4 @@
-defmodule PomeloEx.Cards.Issuing do
+defmodule PomeloEx.General.Company.GetCompany do
   def execute(payload) do
     raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
   end

--- a/lib/pomelo_ex/general/company/modify_company.ex
+++ b/lib/pomelo_ex/general/company/modify_company.ex
@@ -1,4 +1,4 @@
-defmodule PomeloEx.Cards.Issuing do
+defmodule PomeloEx.General.Company.ModifyCompany do
   def execute(payload) do
     raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
   end

--- a/lib/pomelo_ex/general/company/search_companies.ex
+++ b/lib/pomelo_ex/general/company/search_companies.ex
@@ -1,4 +1,4 @@
-defmodule PomeloEx.Cards.Issuing do
+defmodule PomeloEx.General.Company.SearchCompanies do
   def execute(payload) do
     raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
   end

--- a/lib/pomelo_ex/general/users.ex
+++ b/lib/pomelo_ex/general/users.ex
@@ -1,0 +1,308 @@
+defmodule PomeloEx.General.Users do
+  @moduledoc """
+  Users
+  The Users API contains all the endpoints needed to manage the user bases. You can use it to create, update or even search for users within certain parameters.
+  """
+
+  @doc """
+  Create user
+  The /users/v1/ endpoint allows you to create a new user in our database.
+
+  The number of parameters required to create a user varies depending on the product you have signed up for, but we will always ask you for email and operation_country.
+
+  General considerations#
+  For the 'operation_country' and 'nationality' fields we expect a 3-character code respecting the ISO 3166 alpha-3 standard.
+  Here is a list of examples:
+
+  ARG
+  BRA
+  MEX
+  COL
+  PER
+  CHL
+  Considerations for repeat users#
+  Each user must have a unique email, and the combination of identity document type and value must also be unique.
+
+  Considerations on the identity documents#
+  For Argentina
+  Acceptable identity documents are as follows:
+
+  DNI
+  LE
+  LC
+  CI
+  PASSPORT
+  In the case of the DNI, we will validate that its extension is 7 or 8 characters.
+
+  The accepted tax document type is:
+
+  CUIL
+  In the case of CUIL, we will validate that the first two digits are 20, 23, 24, 27, 30, 33 or 34 and its length is exactly 11 characters
+
+  For Brazil
+  Acceptable identity documents are as follows:
+
+  RG
+  CNH
+  The accepted tax document type is:
+
+  CPF
+  In the case of CPF, we will validate that its extension is exactly 11 characters.
+
+  For Mexico
+  Acceptable identity documents are as follows:
+
+  INE
+  PASSPORT
+  The tax document is not required, but the accepted type is:
+
+  RFC
+  En el caso de INE, validaremos que su extensión sea de 12 o 13 caracteres.
+
+  For Colombia
+  Acceptable identity documents are as follows:
+
+  CC
+  CE
+  PPT
+  PASSPORT
+  For CC we will validate that it has between 5 and 11 characters.
+
+  For CE we will validate that it has between 6 and 7 characters.
+
+  Para PPT validaremos que su extensión sea entre 1 y 8 caracteres.
+
+  The tax document is not required, but the accepted type is:
+
+  NIT
+  In the case of the NIT, we will validate that its extension is exactly 10 characters.
+
+  For Peru
+  Acceptable identity documents are as follows:
+
+  DNI
+  CE
+  PASSPORT
+  For the DNI, we will check that its ID number is exactly eight characters long and all numeric
+
+  For the Alien Registration Card, we will check that its ID number is up to 12 alphanumeric characters long
+
+  The accepted tax document type is:
+
+  RUC
+  In the case of RUC, we will validate that the first two digits are 10, 15 or 17 and its extension is 11 digits.
+
+  For Chile
+  Acceptable identity documents are as follows:
+
+  CI
+  In the case of the CI, we will validate that its extension is 8 or 11 characters.
+
+  The accepted tax document type is:
+
+  RUT
+  In the case of the RUT, we will validate that its extension is exactly 9 characters, 8 digits and a verifying character, which can be a digit or a letter k.
+
+  Legal address considerations#
+  For Argentina
+  If you operate in Argentina, the user’s legal address must be from one of these provinces:
+
+  Buenos Aires
+  Catamarca
+  Chaco
+  Chubut
+  Ciudad Autónoma de Buenos Aires
+  Corrientes
+  Córdoba
+  Entre Ríos
+  Formosa
+  Jujuy
+  La Pampa
+  La Rioja
+  Mendoza
+  Misiones
+  Neuquén
+  Río Negro
+  Salta
+  San Juan
+  San Luis
+  Santa Cruz
+  Santa Fe
+  Santiago del Estero
+  Tierra del Fuego
+  Tucumán
+  For Brazil
+  If you operate in Brazil, you must fill out the zipcode field with valid data, as we use it to determine the user's legal address.
+
+  For Mexico
+  If you operate in Mexico, there are no special requirements regarding the user's legal address fields.
+
+  For Chile
+  In case the operating country is Chile, there are no special requirements regarding the user's legal address fields.
+  """
+  alias PomeloEx.General.Users.CreateUser
+  defdelegate create_user(payload), to: CreateUser, as: :execute
+
+  @doc """
+  Search user
+  The /users/v1/ endpoint allows you to search for a group of users and receive a list sorted according to the parameters specified.
+
+  Considerations#
+  Filters must be specified as parameters following this pattern: filter[campo]=valor. For example: /users/v1/?filter[status]=ACTIVE To filter an attribute for several possible values, separate the values with commas. Let's look at an example: filter[status]=ACTIVE,BLOCKED
+
+  The results are paginated and you can specify the amount of data per page and also which page to view using: page[number]=value and page[size]=value
+
+  Sorting#
+  You can specify the order of the results with certain parameters that you must send as list of strings in the sort filter type. For example: ?filter[status]=ACTIVE&sort=status,gender
+
+  The default sorting will be ascending. To specify a descending sorting, you must send the character '-' as a prefix of the attribute. For example: /users/v1/?filter[status]=ACTIVE&sort=status,-gender
+
+  The possible sorting attributes are:
+
+  id
+  gender
+  identification_type
+  identification_value
+  status
+  If a parameter is incorrect or misspelled, it will return an error.
+  """
+  alias PomeloEx.General.Users.SearchUser
+  defdelegate search_user(payload), to: SearchUser, as: :execute
+
+  @doc """
+  Get user
+  The /users/v1/{id} endpoint allows you to query a user’s information through their user_id.
+  """
+  alias PomeloEx.General.Users.GetUser
+  defdelegate get_user(payload), to: GetUser, as: :execute
+
+  @doc """
+  Modify user
+  The endpoint /users/v1/{id} allows you to update a user’s information with their ID.
+
+  Considerations#
+  To block a user you must send the status with the value BLOCKED and the value CLIENT_INTERNAL_REASON in the status_reason field.
+
+  To reactivate a user you have blocked, you will need to send status with value ACTIVE.
+
+  Considerations for repeat users
+  Each user must have a unique email, and the combination of identity document type and value must also be unique.
+
+  Considerations on the identity documents#
+  For Argentina
+  Acceptable identity documents are as follows:
+
+  DNI
+  LE
+  LC
+  CI
+  PASSPORT
+  In the case of the DNI, we will validate that its extension is 7 or 8 characters.
+
+  The accepted tax document type is:
+
+  CUIL
+  In the case of CUIL, we will validate that the first two digits are 20, 23, 24, 27, 30, 33 or 34 and its length is exactly 11 characters
+
+  For Brazil
+  Acceptable identity documents are as follows:
+
+  RG
+  CNH
+  The accepted tax document type is:
+
+  CPF
+  In the case of CPF, we will validate that its extension is exactly 11 characters.
+
+  For Mexico
+  Acceptable identity documents are as follows:
+
+  INE
+  PASSPORT
+  The tax document is not required, but the accepted type is:
+
+  RFC
+  For Colombia
+  Acceptable identity documents are as follows:
+
+  CC
+  CE
+  PPT
+  PASSPORT
+  For CC we will validate that it has between 5 and 11 characters.
+
+  For CE we will validate that it has between 6 and 7 characters.
+
+  Para PPT validaremos que su extensión sea entre 1 y 8 caracteres.
+
+  The tax document is not required, but the accepted type is:
+
+  NIT
+  In the case of the NIT, we will validate that its extension is exactly 10 characters.
+
+  For Peru
+  Acceptable identity documents are as follows:
+
+  DNI
+  CE
+  PASSPORT
+  For the DNI, we will check that its ID number is exactly eight characters long and all numeric
+
+  For the Alien Registration Card, we will check that its ID number is up to 12 alphanumeric characters long
+
+  The accepted tax document type is:
+
+  RUC
+  In the case of RUC, we will validate that the first two digits are 10, 15 or 17 and its extension is 11 digits.
+
+  For Chile
+  Acceptable identity documents are as follows:
+
+  CI
+  In the case of the CI, we will validate that its extension is 8 or 11 characters.
+
+  The accepted tax document type is:
+
+  RUT
+  In the case of the RUT, we will validate that its extension is exactly 9 characters, 8 digits and a verifying character, which can be a digit or a letter k.
+
+  Legal address considerations#
+  For Argentina
+  If you operate in Argentina, the user’s legal address must be from one of these provinces:
+
+  Buenos Aires
+  Catamarca
+  Chaco
+  Chubut
+  Ciudad Autónoma de Buenos Aires
+  Corrientes
+  Córdoba
+  Entre Ríos
+  Formosa
+  Jujuy
+  La Pampa
+  La Rioja
+  Mendoza
+  Misiones
+  Neuquén
+  Río Negro
+  Salta
+  San Juan
+  San Luis
+  Santa Cruz
+  Santa Fe
+  Santiago del Estero
+  Tierra del Fuego
+  Tucumán
+  For Brazil
+  If you operate in Brazil, you must fill out the zipcode field with valid data, as we use it to determine the user's legal address.
+
+  For Mexico
+  If you operate in Mexico, there are no special requirements regarding the user's legal address fields.
+
+  For Chile
+  In case the operating country is Chile, there are no special requirements regarding the user's legal address fields.
+  """
+  alias PomeloEx.General.Users.ModifyUser
+  defdelegate modify_user(payload), to: ModifyUser, as: :execute
+end

--- a/lib/pomelo_ex/general/users/create_user.ex
+++ b/lib/pomelo_ex/general/users/create_user.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Users.CreateUser do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/users/get_user.ex
+++ b/lib/pomelo_ex/general/users/get_user.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Users.GetUser do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/users/modify_user.ex
+++ b/lib/pomelo_ex/general/users/modify_user.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Users.ModifyUser do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/general/users/search_user.ex
+++ b/lib/pomelo_ex/general/users/search_user.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.General.Users.SearchUser do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb.ex
+++ b/lib/pomelo_ex/identity/kyb.ex
@@ -1,0 +1,21 @@
+defmodule PomeloEx.Identity.KYB do
+  @moduledoc """
+  The Identity service lets you manage the onboarding process of companies, partners and employees in a flexible and simple manner, confirming their identity and preventing fraud.
+  """
+
+  alias PomeloEx.Identity.KYB.CancelSession
+  alias PomeloEx.Identity.KYB.CreateSession
+  alias PomeloEx.Identity.KYB.CreateSessionAdditional
+  alias PomeloEx.Identity.KYB.GetSession
+  alias PomeloEx.Identity.KYB.ObtainingSessionReport
+  alias PomeloEx.Identity.KYB.SearchSession
+  alias PomeloEx.Identity.KYB.UploadFile
+
+  defdelegate cancel_session(payload), to: CancelSession, as: :execute
+  defdelegate create_session_additional(payload), to: CreateSessionAdditional, as: :execute
+  defdelegate create_session(payload), to: CreateSession, as: :execute
+  defdelegate get_session(payload), to: GetSession, as: :execute
+  defdelegate obtaining_session_report(payload), to: ObtainingSessionReport, as: :execute
+  defdelegate search_session(payload), to: SearchSession, as: :execute
+  defdelegate upload_file(payload), to: UploadFile, as: :execute
+end

--- a/lib/pomelo_ex/identity/kyb/cancel_session.ex
+++ b/lib/pomelo_ex/identity/kyb/cancel_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.CancelSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/create_session.ex
+++ b/lib/pomelo_ex/identity/kyb/create_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.CreateSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/create_session_additional.ex
+++ b/lib/pomelo_ex/identity/kyb/create_session_additional.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.CreateSessionAdditional do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/get_session.ex
+++ b/lib/pomelo_ex/identity/kyb/get_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.GetSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/obtaining_session_report.ex
+++ b/lib/pomelo_ex/identity/kyb/obtaining_session_report.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.ObtainingSessionReport do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/search_session.ex
+++ b/lib/pomelo_ex/identity/kyb/search_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.SearchSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyb/upload_file.ex
+++ b/lib/pomelo_ex/identity/kyb/upload_file.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYB.UploadFile do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc.ex
+++ b/lib/pomelo_ex/identity/kyc.ex
@@ -1,0 +1,21 @@
+defmodule PomeloEx.Identity.KYC do
+  @moduledoc """
+  The Identity service lets you manage your users’ onboarding process in a flexible and simple manner, confirming their identity and preventing fraud.
+  """
+
+  alias PomeloEx.Identity.KYC.CancelSession
+  alias PomeloEx.Identity.KYC.ClearUserTestEnvironment
+  alias PomeloEx.Identity.KYC.CreateSession
+  alias PomeloEx.Identity.KYC.GetSession
+  alias PomeloEx.Identity.KYC.ObtainingSessionReport
+  alias PomeloEx.Identity.KYC.SearchSession
+  alias PomeloEx.Identity.KYC.UploadFile
+
+  defdelegate cancel_session(payload), to: CancelSession, as: :execute
+  defdelegate clear_user_test_environment(payload), to: ClearUserTestEnvironment, as: :execute
+  defdelegate create_session(payload), to: CreateSession, as: :execute
+  defdelegate get_session(payload), to: GetSession, as: :execute
+  defdelegate obtaining_session_report(payload), to: ObtainingSessionReport, as: :execute
+  defdelegate search_session(payload), to: SearchSession, as: :execute
+  defdelegate upload_file(payload), to: UploadFile, as: :execute
+end

--- a/lib/pomelo_ex/identity/kyc/cancel_session.ex
+++ b/lib/pomelo_ex/identity/kyc/cancel_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.CancelSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/clear_user_test_environment.ex
+++ b/lib/pomelo_ex/identity/kyc/clear_user_test_environment.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.ClearUserTestEnvironment do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/create_session.ex
+++ b/lib/pomelo_ex/identity/kyc/create_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.CreateSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/get_session.ex
+++ b/lib/pomelo_ex/identity/kyc/get_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.GetSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/obtaining_session_report.ex
+++ b/lib/pomelo_ex/identity/kyc/obtaining_session_report.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.ObtainingSessionReport do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/search_session.ex
+++ b/lib/pomelo_ex/identity/kyc/search_session.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.SearchSession do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/kyc/upload_file.ex
+++ b/lib/pomelo_ex/identity/kyc/upload_file.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.KYC.UploadFile do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/webhooks.ex
+++ b/lib/pomelo_ex/identity/webhooks.ex
@@ -1,0 +1,41 @@
+defmodule PomeloEx.Identity.Webhooks do
+  @moduledoc """
+  This service notifies you when an identity validation session is being processed or completed.
+
+  Digital signature request verification process#
+  We send a set of HTTP headers to authenticate it along with the notification.
+
+  The HTTP headers we send are:
+
+    - X-Api-Key : this header allows you to identify which api-secret you have to use in the event that multiple api-key and api-secret pairs have been configured.
+
+    - X-Signature : this header contains the digital signature (timestamp + endpoint + body) that must be verified to ensure the integrity of the request. If the signature does not match, the order must be rejected.
+
+    - X-Timestamp : this header contains the moment the order was signed in unix-epoch format so that you can verify that the signature has not expired.
+
+    - X-Endpoint : the endpoint to which the request is made and used to generate the signature. Use this header to regenerate the signature to be validated, compare it with the endpoint of your service and verify that they match.
+
+  The digital signature is an HMAC-SHA256 code constructed using the 'api-secret' and a series of bytes, composed of a timestamp concatenation, endpoint and request body coded in UTF-8.
+
+  The following is a pseudo-code to verify that the digital signature of a request is legitimate:
+
+  requestSignature = request.headers['x-signature']
+
+  signatureData = encode(request.headers['x-timestamp'] + request.headers['x-endpoint'] + request.body , 'UTF-8')
+
+  clientApiSecretDecoded = base64.b64decode(apiSecret)
+
+  recreatedSignature = hmac(clientApiSecretDecoded, signatureData, 'SHA256')
+
+  validSignature = requestSignature == 'hmac-sha256 ' + recreatedSignature
+  """
+
+  alias PomeloEx.Identity.Webhooks.RequiredFileNotification
+  alias PomeloEx.Identity.Webhooks.ValidationSessionNotifications
+
+  defdelegate required_file_notification(payload), to: RequiredFileNotification, as: :execute
+
+  defdelegate validation_session_notifications(payload),
+    to: ValidationSessionNotifications,
+    as: :execute
+end

--- a/lib/pomelo_ex/identity/webhooks/required_file_notification.ex
+++ b/lib/pomelo_ex/identity/webhooks/required_file_notification.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.Webhooks.RequiredFileNotification do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end

--- a/lib/pomelo_ex/identity/webhooks/validation_session_notifications.ex
+++ b/lib/pomelo_ex/identity/webhooks/validation_session_notifications.ex
@@ -1,0 +1,5 @@
+defmodule PomeloEx.Identity.Webhooks.ValidationSessionNotifications do
+  def execute(payload) do
+    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
+  end
+end


### PR DESCRIPTION
Using Execute Pattern create only interfaces without implementations.

For api:
https://developers.pomelo.la/en/api-reference/

User defdelage for example: 

```elixir 
defmodule PomeloEx.General.Users do
  alias PomeloEx.General.Users.ModifyUser
  defdelegate modify_user(payload), to: ModifyUser, as: :execute
end
```

```elixir 
defmodule PomeloEx.General.Users.ModifyUser do
  def execute(payload) do
    raise "Not implemented #{__MODULE__} payload:" <> inspect(payload)
  end
end

```


